### PR TITLE
Fix AAToggleGenerator sorting

### DIFF
--- a/ZZ_Tools/AAToggleGenerator/MainForm.Designer.cs
+++ b/ZZ_Tools/AAToggleGenerator/MainForm.Designer.cs
@@ -41,7 +41,7 @@
             this.btnAAToggleGen.Name = "btnAAToggleGen";
             this.btnAAToggleGen.Size = new System.Drawing.Size(371, 45);
             this.btnAAToggleGen.TabIndex = 0;
-            this.btnAAToggleGen.Text = "Generate AA bulk toggle sctipt";
+            this.btnAAToggleGen.Text = "Generate AA bulk toggle script";
             this.btnAAToggleGen.UseVisualStyleBackColor = true;
             this.btnAAToggleGen.Click += new System.EventHandler(this.btnAAToggleGen_Click);
             // 

--- a/ZZ_Tools/AAToggleGenerator/MainForm.cs
+++ b/ZZ_Tools/AAToggleGenerator/MainForm.cs
@@ -29,7 +29,7 @@ namespace AAToggleGenerator
                 OpenFileDialog openFileDialog = new OpenFileDialog
                 {
                     Filter = "Cheat Engine Table (*.CT)|*.CT",
-                    Title = "Select a Cheat Engine Table for re-nmber"
+                    Title = "Select a Cheat Engine Table for renumber"
                 };
 
                 if (openFileDialog.ShowDialog() == DialogResult.OK)

--- a/ZZ_Tools/AAToggleGenerator/ScriptGenerator.cs
+++ b/ZZ_Tools/AAToggleGenerator/ScriptGenerator.cs
@@ -345,11 +345,20 @@ namespace AAToggleGenerator
             }
         }
 
+        private static int ParseId(string id)
+        {
+            return int.TryParse(id, out var result) ? result : int.MaxValue;
+        }
+
         private static List<CheatEntry> GetOrderedEntries(List<CheatEntry> entries, bool ascending)
         {
             return ascending
-                ? entries.OrderBy(e => e.Depth).ThenBy(e => e.Id).ToList()
-                : entries.OrderByDescending(e => e.Depth).ThenByDescending(e => e.Id).ToList();
+                ? entries.OrderBy(e => e.Depth)
+                         .ThenBy(e => ParseId(e.Id))
+                         .ToList()
+                : entries.OrderByDescending(e => e.Depth)
+                         .ThenByDescending(e => ParseId(e.Id))
+                         .ToList();
         }
     }
 


### PR DESCRIPTION
## Summary
- correct numeric ordering of cheat entries
- fix typos in UI text

## Testing
- `mcs --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841b43869588330a60773fe83da45f3