### PR TITLE
Add script generation test for hierarchy ordering

### DIFF
--- a/ZZ_Tools/AAToggleGenerator/ScriptGenerator.cs
+++ b/ZZ_Tools/AAToggleGenerator/ScriptGenerator.cs
@@ -269,6 +269,15 @@ namespace AAToggleGenerator
 
         private static void GenerateAndShowScript(List<CheatEntry> selectedEntries, List<CheatEntry> allEntries)
         {
+            string script = BuildScript(selectedEntries, allEntries);
+            if (!TestMode)
+            {
+                ShowScriptWithHighlighting(script);
+            }
+        }
+
+        internal static string BuildScript(List<CheatEntry> selectedEntries, List<CheatEntry> allEntries)
+        {
             // Ensure correct order
             var enableOrder = GetOrderedEntries(selectedEntries, true);
             var disableOrder = GetOrderedEntries(allEntries, false);
@@ -338,8 +347,7 @@ namespace AAToggleGenerator
                 scriptBuilder.AppendLine($"-- {indent}ID: {entry.Id}, Description: {entry.Description}, Depth: {entry.Depth}");
             }
 
-            // Add syntax highlighting using Scintilla
-            ShowScriptWithHighlighting(scriptBuilder.ToString());
+            return scriptBuilder.ToString();
         }
 
         private static void ShowScriptWithHighlighting(string script)


### PR DESCRIPTION
## Summary
- Add `BuildScript` helper to generate ordered ENABLE/DISABLE sections with depth-aware comments
- Test script generation for `sample_simple.CT`, asserting ENABLE ascending, DISABLE descending, and preserved comment depth

## Testing
- `dotnet test ZZ_Tools/AAToggleGenerator/AAToggleGenerator.sln` *(fails: The imported project "/usr/lib/dotnet/sdk/8.0.119/Sdks/Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets" was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b44062a11c8330b51eab97e8d61e54