### PR TITLE
Add RenumberIDs tests and test hooks

### DIFF
--- a/ZZ_Tools/AAToggleGenerator.Tests/CTFileIDProcessorTests.cs
+++ b/ZZ_Tools/AAToggleGenerator.Tests/CTFileIDProcessorTests.cs
@@ -1,0 +1,93 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using AAToggleGenerator;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace AAToggleGenerator.Tests
+{
+    [TestClass]
+    public class CTFileIDProcessorTests
+    {
+        [TestMethod]
+        public void RenumberIDs_RewritesSequentiallyAndCreatesBackup()
+        {
+            if (!OperatingSystem.IsWindows())
+            {
+                Assert.Inconclusive("Windows-only test");
+            }
+
+            string tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(tempDir);
+            try
+            {
+                string filePath = Path.Combine(tempDir, "test.CT");
+                string content = @"<CheatTable><CheatEntries>
+  <CheatEntry><ID>5</ID></CheatEntry>
+  <CheatEntry><ID>8</ID></CheatEntry>
+  <CheatEntry><ID>10</ID></CheatEntry>
+</CheatEntries></CheatTable>";
+                File.WriteAllText(filePath, content);
+
+                CTFileIDProcessor.TestMode = true;
+                CTFileIDProcessor.LastMessages.Clear();
+                CTFileIDProcessor.RenumberIDs(filePath);
+
+                string updated = File.ReadAllText(filePath);
+                var ids = Regex.Matches(updated, @"<ID>(\d+)</ID>")
+                               .Select(m => m.Groups[1].Value)
+                               .ToArray();
+                CollectionAssert.AreEqual(new[] { "0", "1", "2" }, ids);
+
+                string[] backups = Directory.GetFiles(tempDir, "test.CT.bak.*");
+                Assert.AreEqual(1, backups.Length);
+                Assert.IsTrue(File.Exists(backups[0]));
+                Assert.IsTrue(CTFileIDProcessor.LastMessages.Any(m => m.StartsWith("Backup created:")));
+            }
+            finally
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+
+        [TestMethod]
+        public void RenumberIDs_InvalidPath_ShowsAlert()
+        {
+            if (!OperatingSystem.IsWindows())
+            {
+                Assert.Inconclusive("Windows-only test");
+            }
+
+            CTFileIDProcessor.TestMode = true;
+            CTFileIDProcessor.LastMessages.Clear();
+            string path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".CT");
+            CTFileIDProcessor.RenumberIDs(path);
+            Assert.AreEqual($"File not found: {path}", CTFileIDProcessor.LastMessages.Single());
+        }
+
+        [TestMethod]
+        public void RenumberIDs_InvalidExtension_ShowsAlert()
+        {
+            if (!OperatingSystem.IsWindows())
+            {
+                Assert.Inconclusive("Windows-only test");
+            }
+
+            string tempFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".txt");
+            File.WriteAllText(tempFile, "dummy");
+            try
+            {
+                CTFileIDProcessor.TestMode = true;
+                CTFileIDProcessor.LastMessages.Clear();
+                CTFileIDProcessor.RenumberIDs(tempFile);
+                Assert.AreEqual("Selected file must be a .CT file.", CTFileIDProcessor.LastMessages.Single());
+            }
+            finally
+            {
+                File.Delete(tempFile);
+            }
+        }
+    }
+}
+

--- a/ZZ_Tools/AAToggleGenerator/CTFileIDProcessor.cs
+++ b/ZZ_Tools/AAToggleGenerator/CTFileIDProcessor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
@@ -7,6 +8,21 @@ namespace AAToggleGenerator
 {
     public class CTFileIDProcessor
     {
+        // Test hooks
+        internal static bool TestMode { get; set; }
+        internal static List<string> LastMessages { get; } = new List<string>();
+
+        private static void ShowMessage(string message, string caption, MessageBoxButtons buttons, MessageBoxIcon icon)
+        {
+            if (TestMode)
+            {
+                LastMessages.Add(message);
+            }
+            else
+            {
+                MessageBox.Show(message, caption, buttons, icon);
+            }
+        }
         /// <summary>
         /// Renumber <ID> nodes in the .CT file using regex for efficiency.
         /// </summary>
@@ -16,19 +32,19 @@ namespace AAToggleGenerator
             // Input validation
             if (string.IsNullOrWhiteSpace(filePath))
             {
-                MessageBox.Show("File path cannot be null or empty.", "Validation Error", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                ShowMessage("File path cannot be null or empty.", "Validation Error", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 return;
             }
 
             if (!File.Exists(filePath))
             {
-                MessageBox.Show($"File not found: {filePath}", "File Error", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                ShowMessage($"File not found: {filePath}", "File Error", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 return;
             }
 
             if (!filePath.EndsWith(".CT", StringComparison.OrdinalIgnoreCase))
             {
-                MessageBox.Show("Selected file must be a .CT file.", "File Type Error", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                ShowMessage("Selected file must be a .CT file.", "File Type Error", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 return;
             }
 
@@ -48,20 +64,20 @@ namespace AAToggleGenerator
                 }
                 catch (UnauthorizedAccessException)
                 {
-                    MessageBox.Show("Access denied. Please check file permissions.", "Access Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    ShowMessage("Access denied. Please check file permissions.", "Access Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                     return;
                 }
 
                 if (string.IsNullOrEmpty(originalContent))
                 {
-                    MessageBox.Show("The selected file is empty.", "File Error", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    ShowMessage("The selected file is empty.", "File Error", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                     return;
                 }
 
                 // Create a backup with better collision handling
                 string backupFilePath = GenerateBackupPath(filePath);
                 File.WriteAllText(backupFilePath, originalContent);
-                MessageBox.Show($"Backup created: {backupFilePath}", "Backup Success", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                ShowMessage($"Backup created: {backupFilePath}", "Backup Success", MessageBoxButtons.OK, MessageBoxIcon.Information);
 
                 // Perform regex replacement to renumber <ID> nodes
                 int idCounter = 0;
@@ -73,25 +89,25 @@ namespace AAToggleGenerator
                 // Verify changes were made
                 if (modifiedContent == originalContent)
                 {
-                    MessageBox.Show("No ID tags found to renumber.", "No Changes", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                    ShowMessage("No ID tags found to renumber.", "No Changes", MessageBoxButtons.OK, MessageBoxIcon.Information);
                     return;
                 }
 
                 // Write the modified content back to the original file
                 File.WriteAllText(filePath, modifiedContent);
-                MessageBox.Show($"IDs successfully renumbered and saved!\nTotal IDs: {idCounter}", "Success", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                ShowMessage($"IDs successfully renumbered and saved!\nTotal IDs: {idCounter}", "Success", MessageBoxButtons.OK, MessageBoxIcon.Information);
             }
             catch (IOException ex)
             {
-                MessageBox.Show($"File I/O error: {ex.Message}", "I/O Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                ShowMessage($"File I/O error: {ex.Message}", "I/O Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
             catch (RegexMatchTimeoutException)
             {
-                MessageBox.Show("Operation timed out. The file may be too large.", "Timeout Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                ShowMessage("Operation timed out. The file may be too large.", "Timeout Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
             catch (Exception ex)
             {
-                MessageBox.Show($"An unexpected error occurred: {ex.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                ShowMessage($"An unexpected error occurred: {ex.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 


### PR DESCRIPTION
## Summary
- expose `TestMode` and message collection in `CTFileIDProcessor` for testing
- add unit tests covering ID renumbering and validation messages

## Testing
- ⚠️ `dotnet test ZZ_Tools/AAToggleGenerator/AAToggleGenerator.sln` *(failed: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b44578ec7083309834448ce0a9991a