### PR TITLE
Add tests for Windows theme helper with environment mocks

### DIFF
--- a/ZZ_Tools/AAToggleGenerator.Tests/AAToggleGenerator.Tests.csproj
+++ b/ZZ_Tools/AAToggleGenerator.Tests/AAToggleGenerator.Tests.csproj
@@ -8,9 +8,11 @@
 
   <ItemGroup>
     <Compile Include="../AAToggleGenerator/CTRenameEXE2Process.cs" Link="CTRenameEXE2Process.cs" />
+    <Compile Include="../AAToggleGenerator/WindowsThemeHelper.cs" Link="WindowsThemeHelper.cs" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.2.0" />
     <PackageReference Include="MSTest.TestFramework" Version="3.2.0" />
+    <PackageReference Include="System.Drawing.Common" Version="8.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ZZ_Tools/AAToggleGenerator.Tests/WindowsThemeHelperTests.cs
+++ b/ZZ_Tools/AAToggleGenerator.Tests/WindowsThemeHelperTests.cs
@@ -1,0 +1,76 @@
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace AAToggleGenerator.Tests
+{
+    [TestClass]
+    public class WindowsThemeHelperTests
+    {
+        [TestInitialize]
+        public void Setup()
+        {
+            WindowsThemeHelper.RegistryGetValueFunc = Microsoft.Win32.Registry.GetValue;
+            WindowsThemeHelper.BuildNumberProvider = null;
+            WindowsThemeHelper.DwmSetWindowAttributeOverride = null;
+        }
+
+        [TestMethod]
+        public void GetCurrentTheme_ReturnsLight_WhenRegistryValueIsLight()
+        {
+            WindowsThemeHelper.BuildNumberProvider = () => 19045;
+            WindowsThemeHelper.RegistryGetValueFunc = (key, value, defaultVal) => 1;
+            Assert.AreEqual(WindowsThemeHelper.WindowsTheme.Light, WindowsThemeHelper.GetCurrentTheme());
+        }
+
+        [TestMethod]
+        public void GetCurrentTheme_ReturnsDark_WhenRegistryValueIsDark()
+        {
+            WindowsThemeHelper.BuildNumberProvider = () => 19045;
+            WindowsThemeHelper.RegistryGetValueFunc = (key, value, defaultVal) => 0;
+            Assert.AreEqual(WindowsThemeHelper.WindowsTheme.Dark, WindowsThemeHelper.GetCurrentTheme());
+        }
+
+        [TestMethod]
+        public void IsThemeAwareSupported_ReflectsBuildNumber()
+        {
+            WindowsThemeHelper.BuildNumberProvider = () => 1000;
+            Assert.IsFalse(WindowsThemeHelper.IsThemeAwareSupported());
+            WindowsThemeHelper.BuildNumberProvider = () => 19045;
+            Assert.IsTrue(WindowsThemeHelper.IsThemeAwareSupported());
+        }
+
+        [TestMethod]
+        public void TryApplyDarkTitleBar_ReturnsFalse_WithZeroHandle()
+        {
+            WindowsThemeHelper.BuildNumberProvider = () => 19045;
+            WindowsThemeHelper.RegistryGetValueFunc = (k, v, d) => 0;
+            Assert.IsFalse(WindowsThemeHelper.TryApplyDarkTitleBar(IntPtr.Zero));
+        }
+
+        [TestMethod]
+        public void TryApplyDarkTitleBar_ReturnsTrue_WhenDwmSucceeds()
+        {
+            WindowsThemeHelper.BuildNumberProvider = () => 19045;
+            WindowsThemeHelper.RegistryGetValueFunc = (k, v, d) => 0;
+            WindowsThemeHelper.DwmSetWindowAttributeOverride = (IntPtr hwnd, int attr, ref int val, int size) => 0;
+            Assert.IsTrue(WindowsThemeHelper.TryApplyDarkTitleBar(new IntPtr(1)));
+        }
+
+        [TestMethod]
+        public void ApplyTitleBarTheme_ReturnsFalse_WhenUnsupported()
+        {
+            WindowsThemeHelper.BuildNumberProvider = () => 1000;
+            WindowsThemeHelper.RegistryGetValueFunc = (k, v, d) => 0;
+            Assert.IsFalse(WindowsThemeHelper.ApplyTitleBarTheme(new IntPtr(1)));
+        }
+
+        [TestMethod]
+        public void ApplyTitleBarTheme_ReturnsTrue_WhenDwmSucceeds()
+        {
+            WindowsThemeHelper.BuildNumberProvider = () => 19045;
+            WindowsThemeHelper.RegistryGetValueFunc = (k, v, d) => 0;
+            WindowsThemeHelper.DwmSetWindowAttributeOverride = (IntPtr hwnd, int attr, ref int val, int size) => 0;
+            Assert.IsTrue(WindowsThemeHelper.ApplyTitleBarTheme(new IntPtr(1)));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- allow WindowsThemeHelper to override registry/build number and DWM calls for testing
- add unit tests covering theme detection, support checks, and title bar application

## Testing
- `dotnet test ZZ_Tools/AAToggleGenerator.Tests/AAToggleGenerator.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b449372a348330bbfec27d281c096c