### PR TITLE
Add tests for theme extensions

### DIFF
--- a/ZZ_Tools/AAToggleGenerator.Tests/AAToggleGenerator.Tests.csproj
+++ b/ZZ_Tools/AAToggleGenerator.Tests/AAToggleGenerator.Tests.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <Compile Include="../AAToggleGenerator/CTRenameEXE2Process.cs" Link="CTRenameEXE2Process.cs" />
     <Compile Include="../AAToggleGenerator/WindowsThemeHelper.cs" Link="WindowsThemeHelper.cs" />
+    <Compile Include="../AAToggleGenerator/ThemeExtensions.cs" Link="ThemeExtensions.cs" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.2.0" />
     <PackageReference Include="MSTest.TestFramework" Version="3.2.0" />

--- a/ZZ_Tools/AAToggleGenerator.Tests/ThemeExtensionsTests.cs
+++ b/ZZ_Tools/AAToggleGenerator.Tests/ThemeExtensionsTests.cs
@@ -1,0 +1,60 @@
+using System.Drawing;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace AAToggleGenerator.Tests
+{
+    [TestClass]
+    public class ThemeExtensionsTests
+    {
+        [TestInitialize]
+        public void Setup()
+        {
+            WindowsThemeHelper.RegistryGetValueFunc = Microsoft.Win32.Registry.GetValue;
+            WindowsThemeHelper.BuildNumberProvider = null;
+            WindowsThemeHelper.DwmSetWindowAttributeOverride = null;
+        }
+
+        [TestMethod]
+        public void ApplyTheme_SetsColorsForFormAndChildren()
+        {
+            WindowsThemeHelper.BuildNumberProvider = () => 19045;
+            WindowsThemeHelper.RegistryGetValueFunc = (k, v, d) => 0; // Dark theme
+
+            var form = new System.Windows.Forms.Form();
+            var button = new System.Windows.Forms.Button();
+            var treeView = new System.Windows.Forms.TreeView();
+
+            form.Controls.Add(button);
+            form.Controls.Add(treeView);
+
+            form.ApplyTheme();
+
+            var bg = WindowsThemeHelper.GetBackgroundColor();
+            var fg = WindowsThemeHelper.GetForegroundColor();
+            var btnBg = WindowsThemeHelper.GetButtonBackgroundColor();
+
+            Assert.AreEqual(bg, form.BackColor);
+            Assert.AreEqual(fg, form.ForeColor);
+            Assert.AreEqual(btnBg, button.BackColor);
+            Assert.AreEqual(fg, button.ForeColor);
+            Assert.AreEqual(bg, treeView.BackColor);
+            Assert.AreEqual(fg, treeView.ForeColor);
+        }
+
+        [TestMethod]
+        public void UpdateNodeTheme_GroupNode_ChangesWithTheme()
+        {
+            WindowsThemeHelper.BuildNumberProvider = () => 19045;
+            var node = new System.Windows.Forms.TreeNode("Group");
+
+            WindowsThemeHelper.RegistryGetValueFunc = (k, v, d) => 0; // Dark
+            node.UpdateNodeTheme(isGroup: true);
+            Assert.AreEqual(Color.FromArgb(128, 128, 128), node.ForeColor);
+
+            WindowsThemeHelper.RegistryGetValueFunc = (k, v, d) => 1; // Light
+            node.UpdateNodeTheme(isGroup: true);
+            Assert.AreEqual(Color.Gray, node.ForeColor);
+        }
+    }
+}
+

--- a/ZZ_Tools/AAToggleGenerator.Tests/WinFormsStubs.cs
+++ b/ZZ_Tools/AAToggleGenerator.Tests/WinFormsStubs.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Drawing;
+
+namespace System.Windows.Forms
+{
+    public class Control
+    {
+        public Color BackColor { get; set; }
+        public Color ForeColor { get; set; }
+        public ControlCollection Controls { get; }
+        public bool HasChildren => Controls.Count > 0;
+
+        public Control()
+        {
+            Controls = new ControlCollection(this);
+        }
+
+        public class ControlCollection : IEnumerable<Control>
+        {
+            private readonly List<Control> _controls = new();
+
+            public ControlCollection(Control owner) { }
+
+            public void Add(Control control) => _controls.Add(control);
+
+            public int Count => _controls.Count;
+
+            public IEnumerator<Control> GetEnumerator() => _controls.GetEnumerator();
+
+            IEnumerator IEnumerable.GetEnumerator() => _controls.GetEnumerator();
+        }
+    }
+
+    public class Form : Control
+    {
+        public bool IsHandleCreated { get; set; }
+        public IntPtr Handle { get; set; }
+        public event EventHandler? HandleCreated;
+    }
+
+    public class Button : Control
+    {
+        public FlatStyle FlatStyle { get; set; }
+        public FlatAppearance FlatAppearance { get; } = new();
+    }
+
+    public class FlatAppearance
+    {
+        public Color BorderColor { get; set; }
+        public int BorderSize { get; set; }
+        public Color MouseOverBackColor { get; set; }
+        public Color MouseDownBackColor { get; set; }
+    }
+
+    public enum FlatStyle
+    {
+        Flat
+    }
+
+    public class Label : Control { }
+
+    public class NumericUpDown : Control
+    {
+        public BorderStyle BorderStyle { get; set; }
+    }
+
+    public enum BorderStyle
+    {
+        FixedSingle
+    }
+
+    public class TreeView : Control
+    {
+        public List<TreeNode> Nodes { get; } = new();
+        public Color LineColor { get; set; }
+        public BorderStyle BorderStyle { get; set; }
+    }
+
+    public class TreeNode
+    {
+        public TreeNode(string? text = null) { }
+
+        public Color ForeColor { get; set; }
+    }
+}
+
+namespace ScintillaNET
+{
+    using System.Windows.Forms;
+
+    public class Scintilla : Control
+    {
+        public StyleCollection Styles { get; } = new();
+        public Color CaretForeColor { get; set; }
+        public void SetSelectionBackColor(bool use, Color color) { }
+    }
+
+    public class StyleCollection
+    {
+        private readonly Dictionary<int, Style> _styles = new();
+
+        public Style this[int index]
+        {
+            get
+            {
+                if (!_styles.TryGetValue(index, out var style))
+                {
+                    style = new Style();
+                    _styles[index] = style;
+                }
+                return style;
+            }
+        }
+    }
+
+    public class Style
+    {
+        public Color BackColor { get; set; }
+        public Color ForeColor { get; set; }
+
+        public const int Default = 0;
+
+        public static class Lua
+        {
+            public const int Default = 1;
+            public const int Comment = 2;
+            public const int CommentLine = 3;
+            public const int CommentDoc = 4;
+            public const int Number = 5;
+            public const int Word = 6;
+            public const int String = 7;
+            public const int Character = 8;
+            public const int LiteralString = 9;
+            public const int Preprocessor = 10;
+            public const int Operator = 11;
+            public const int Identifier = 12;
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add lightweight WinForms/Scintilla stubs for headless testing
- exercise ThemeExtensions on a form with button and TreeView
- verify group node styling matches WindowsThemeHelper colors

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b44b158bd88330a1f72f27ebfa9cb7